### PR TITLE
feat: change default fold settings

### DIFF
--- a/nvim/lua/lobak/autocmd.lua
+++ b/nvim/lua/lobak/autocmd.lua
@@ -4,6 +4,7 @@ local augroup = vim.api.nvim_create_augroup
 local TrimWhitespaceGroup = augroup('TrimWhitespace', {})
 local TextFormatGroup = augroup('TextFormat', { clear = true })
 local TextYankGroup = augroup('TextYank', { clear = true })
+local FoldingGroup = augroup('CodeFold', { clear = true })
 
 -- Trim whitespace when saving files
 autocmd({ 'BufWritePre' }, {
@@ -17,6 +18,14 @@ autocmd({ 'BufWinEnter' }, {
   group = TextFormatGroup,
   buffer = 0,
   command = 'set formatoptions-=t'
+})
+
+-- Allow code to exceed vim.opt.textwidth
+autocmd({ 'BufWinEnter' }, {
+  group = FoldingGroup,
+  callback = function ()
+    vim.cmd('normal zR')
+  end
 })
 
 -- Highlight text that is being yanked

--- a/nvim/lua/lobak/autocmd.lua
+++ b/nvim/lua/lobak/autocmd.lua
@@ -2,25 +2,25 @@ local autocmd = vim.api.nvim_create_autocmd
 local augroup = vim.api.nvim_create_augroup
 
 local TrimWhitespaceGroup = augroup('TrimWhitespace', {})
-local TextFormatGroup = augroup("TextFormat", { clear = true })
-local TextYankGroup = augroup("TextYank", { clear = true })
+local TextFormatGroup = augroup('TextFormat', { clear = true })
+local TextYankGroup = augroup('TextYank', { clear = true })
 
 -- Trim whitespace when saving files
-autocmd({ "BufWritePre" }, {
+autocmd({ 'BufWritePre' }, {
   group = TrimWhitespaceGroup,
-  pattern = "*",
+  pattern = '*',
   command = [[%s/\s\+$//e]],
 })
 
 -- Allow code to exceed vim.opt.textwidth
-autocmd({ "BufWinEnter" }, {
+autocmd({ 'BufWinEnter' }, {
   group = TextFormatGroup,
   buffer = 0,
-  command = "set formatoptions-=t"
+  command = 'set formatoptions-=t'
 })
 
 -- Highlight text that is being yanked
-autocmd({ "TextYankPost" }, {
+autocmd({ 'TextYankPost' }, {
   group = TextYankGroup,
   callback = function ()
     vim.highlight.on_yank()

--- a/nvim/lua/lobak/set.lua
+++ b/nvim/lua/lobak/set.lua
@@ -46,5 +46,4 @@ vim.opt.signcolumn = "yes"
 vim.opt.colorcolumn = "80"
 vim.opt.termguicolors = true
 
-vim.opt.foldlevel = 99
 vim.opt.foldmethod = 'indent'


### PR DESCRIPTION
This just changes how the foldlevel gets set. foldlevel defaulting to 99 works, but if you decrease the fold, you either have to hit zR to set it to the max level, or zM all the way down. Instead of setting it to 99, run zR when opening a buffer, which sets foldlevel to the max fold in that file.