### PR TITLE
fix: issue with neovim not picking up the filetype on empty/new terraform files

### DIFF
--- a/nvim/lsp/tofu_ls.lua
+++ b/nvim/lsp/tofu_ls.lua
@@ -1,5 +1,13 @@
+-- There is some strangeness around detecting filetypes, use this to enforce it
+vim.filetype.add({
+  extension = {
+    tf = 'opentofu',
+    tofu = 'opentofu',
+  }
+})
+
 return {
   cmd = { 'tofu-ls', 'serve' },
-  filetypes = { 'terraform', 'terraform-vars', 'tf' },
+  filetypes = { 'terraform', 'terraform-vars', 'tf', 'opentofu', 'opentofu-vars' },
   root_markers = { '.terraform', '.git' },
 }


### PR DESCRIPTION
form files