### PR TITLE
feat: made it so aws-login will unset credentials before logging in

### DIFF
--- a/zsh/.zfunc/aws-login
+++ b/zsh/.zfunc/aws-login
@@ -21,6 +21,12 @@ if [[ -z "${ROLE_ARN}" || -z "${SERIAL_ARN}" ]];then
   return
 fi
 
+# Unset existing values as this will cause the assume role to fail
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+unset AWS_PROFILE
+
 JSON=$(aws sts assume-role --role-arn ${ROLE_ARN} --role-session-name ${SESSION_NAME} --serial-number ${SERIAL_ARN} --token-code ${2})
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Previously if you logged in to an account via

c

You would have to logout before changing profiles, e.g

```bash
aws-logout
aws-login other 222333
```

It now unsets the env variables when running login, disconnecting you from the account (not a true logout because you can't do this without manually setting an expiration date on the session). Now you can do this if you want.

```bash
aws-login profile 111222
aws-login scooby 222333
aws-login dooby 333444
```