### PR TITLE
fix: changed filetype for tofu files to terraform

### DIFF
--- a/nvim/lua/config/filetypes.lua
+++ b/nvim/lua/config/filetypes.lua
@@ -4,7 +4,7 @@ vim.filetype.add({
     tf = 'terraform',
     tfvars = 'terraform-vars',
     tfstate = 'terraform',
-    tofu = 'opentofu',
+    tofu = 'terraform',
   }
 })
 


### PR DESCRIPTION
Reason: tofu files are missing commentstrings and are noticeably slower